### PR TITLE
update `QPC_COMMIT` env var in downstream `Dockerfile`

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,12 +56,11 @@ def update_remote_sources(distgit_path: Path = distgit_path_arg):
     """
     Update remote-sources on 'container.yaml' based on 'sources-version.yaml'.
 
-    If changes are detected to quipucords-server, than this will also invoke
+    If changes are detected to commit refs, then this will also invoke
     the following subcommands:
 
-    - update-quipucords-sha
-
-    - update-rust-deps dependencies when a version change is detected.
+    - update_dockerfile
+    - update_rust_deps dependencies when a version change is detected.
 
     Check --help method of these subcommands for more info.
     """


### PR DESCRIPTION
Updating the new `QPC_COMMIT` env var will be required to support `qpc`'s new `--build-sha` hidden argument (https://github.com/quipucords/qpc/pull/260 https://github.com/quipucords/qpc/pull/262) in downstream builds. That will also require a small update to the downstream `Dockerfile` not included here.

Since there are no automated tests, I tested this manually by running this version of chaski in my downstream builder image, and I confirmed that it updated the `QPC_COMMIT` value correctly.

Relates to JIRA: DISCOVERY-359
https://issues.redhat.com/browse/DISCOVERY-359
