### PR TITLE
chore(lint): disable pydocstyle check for __init__ methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ select = [
     "PTH", # flake8-use-pathlib
 ]
 ignore = [
+    "D107",
     "D203", 
     "D403",
 ]


### PR DESCRIPTION
Relax the rules for pydocstyle checks. Allow having empty __init__ methods.